### PR TITLE
build Gallery2

### DIFF
--- a/config/bliss_packages.mk
+++ b/config/bliss_packages.mk
@@ -17,6 +17,7 @@ endif
 # Bliss Packages
 PRODUCT_PACKAGES += \
     DeskClock \
+    Gallery2 \
     LatinIME \
     Recorder \
     LineageParts \


### PR DESCRIPTION
since d55d4e78ce636c3a5e006304c4ef74a5890ee194, there's no gallery app anymore on r11, and simple mobile tools is dead

according to https://github.com/BlissRoms-x86/manifest/blob/94f8bfc66f4955e415996db8e9243490231f1ddd/bliss.xml#L94 , this will build https://github.com/BlissRoms-x86/platform_packages_apps_Gallery2/tree/r11

for reference, arcadia manifest clones the one on aosp, while typhoon manifest clones the lineageos one

On typhoon and arcadia, Gallery2 build target was defined at https://github.com/BlissRoms-x86/platform_build/blob/arcadia-x86/target/product/handheld_product.mk instead, while on r11, `handheld_product.mk` was modified to move most package targets to `bliss_packages.mk` on this repo